### PR TITLE
Log reason for request error

### DIFF
--- a/src/manot/manot.py
+++ b/src/manot/manot.py
@@ -59,8 +59,8 @@ class manotAI:
 
         try:
             response = requests.post(url=url, data=json.dumps(arguments), headers={"token": self.__token})
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if response.status_code == 202:
@@ -82,8 +82,8 @@ class manotAI:
 
         try:
             response = requests.get(url=url)
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if response.status_code != 200:
@@ -115,8 +115,8 @@ class manotAI:
 
         try:
             response = requests.post(url=url, data=json.dumps(data), headers={"token": self.__token})
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if response.status_code == 202:
@@ -138,8 +138,8 @@ class manotAI:
 
         try:
             response = requests.get(url=url)
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if response.status_code != 200:
@@ -153,8 +153,8 @@ class manotAI:
 
         try:
             response = requests.get(url=url).json()
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if not response:
@@ -198,8 +198,8 @@ class manotAI:
 
         try:
             response = requests.post(url=url, data=json.dumps(data), headers={"token": self.__token})
-        except Exception:
-            log.error("There is problem with request.")
+        except requests.exceptions.RequestException as e:
+            log.error("There is problem with request: [%s] %s" % (type(e).__name__, str(e)))
             return False
 
         if response.status_code == 200:


### PR DESCRIPTION
- Log the error type and the error cause
- Don't catch wildcard exceptions since that can make debugging really hard