### PR TITLE
Fix misspelled function name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ insight_info = manot.get_insight(insight["id"])
 ```
 
 ```
-scores = manot.get_scores(insight['id'])
+scores = manot.get_score(insight['id'])
 #returns list of all processed images graded by their score from 0 to 10 (higher is more impactful image)
 ```
 


### PR DESCRIPTION
The function is actually called `get_score` but the docs/readme says `get_scores`.